### PR TITLE
moved tag manager script to partial and included it on all pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,13 +11,7 @@
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NTSCMBT');</script>
-    <!-- End Google Tag Manager -->
+    {% include tag_manager_head.html %}
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ "/assets/css/p2pu-custom.css" | prepend: site.baseurl }}">

--- a/_includes/tag_manager_foot.html
+++ b/_includes/tag_manager_foot.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NTSCMBT"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/_includes/tag_manager_head.html
+++ b/_includes/tag_manager_head.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NTSCMBT');</script>
+<!-- End Google Tag Manager -->

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -5,11 +5,6 @@
 <!--[if gt IE 8]><!--> <html lang="{{language}}" class="no-js"> <!--<![endif]-->
   {% include head.html %}
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NTSCMBT"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-
     {% include nav.html %}
 
     <div class="page-content">
@@ -23,4 +18,5 @@
     {% include ga.html %}
 
   </body>
+  {% include tag_manager_foot.html %}
 </html>

--- a/en/index.html
+++ b/en/index.html
@@ -19,6 +19,7 @@ bundles:
 <html lang="en" class="no-js"> <!--<![endif]-->
 
 <head>
+	{% include tag_manager_head.html %}
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
@@ -192,4 +193,6 @@ bundles:
 {% include ga.html %}
 
 </body>
+
+{% include tag_manager_foot.html %}
 </html>


### PR DESCRIPTION
I previously added the Tag Manager script to the head.html and base.html partials, which as it turns out, aren't used for the homepage. So now it's in its own partial that's included in the head, base, and homepage templates.