### PR TITLE
alternative spacing for partners

### DIFF
--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -386,6 +386,10 @@ main {
 
 	section#partners-and-funders {
 		.partners {
+			display: flex;
+	    flex-wrap: wrap;
+	    align-items: center;
+
 			> div {
 				text-align: center;
 				margin-bottom: $padding-sm;


### PR DESCRIPTION
Check and see if you like this spacing better, either way it's not going to be uniform spacing on this line because the "Hillsborough County Public Library Cooperative" wraps so it takes up more space than the other partners on this row. 