### PR TITLE
Add cluster map to home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,9 @@ sass:
 
 env: prod
 
+mapbox_access_token: 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ'
+default_base_api_endpoint: 'http://localhost:8000'
+
 exclude:
   - Guardfile
   - Gemfile

--- a/_includes/map_js.html
+++ b/_includes/map_js.html
@@ -1,0 +1,51 @@
+<script type="text/javascript">
+  var url = "{{ site.default_base_api_endpoint }}/api/learning-circles-map/"
+
+  var accessToken = "{{ site.mapbox_access_token }}"
+  var tileLayer = "https://api.mapbox.com/styles/v1/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw/tiles/256/{z}/{x}/{y}@2x?access_token=" + accessToken;
+
+  var mymap = L.map('global-map', {
+    scrollWheelZoom: false,
+  }).setView([20, 10], 2.2);
+
+  L.tileLayer(tileLayer, {
+      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+      maxZoom: 18,
+      id: 'mapbox.streets',
+      accessToken: accessToken,
+  }).addTo(mymap);
+
+  var markerClusters = L.markerClusterGroup();
+
+  $.ajax({
+    url,
+    dataType: 'JSONP',
+    type: 'GET',
+    success: (res) => {
+      $.each(res.items, function(index, item) {
+        if (item.latitude && item.longitude) {
+          var classes = item.active ? "marker active" : "marker";
+          var markerIcon = L.divIcon({className: classes});
+          var m = L.marker( [item.latitude, item.longitude], { icon: markerIcon } )
+
+          var popupContent = "";
+          var title = "<div><strong>" + item.title + "</strong></div>";
+          var year = "<div>" + item.city + ", " + item.start_date.substring(0,4) + "</div>";
+
+          popupContent += title
+          popupContent += year
+
+          if (item.url) {
+            var anchorText = item.active ? "Signup page" : "Final report";
+            var link = "<div><a href='" + item.url + "' target='_blank'>" + anchorText + "</a></div>"
+            popupContent += link
+          }
+
+          m.bindPopup(popupContent)
+          markerClusters.addLayer( m );
+        }
+      })
+      mymap.addLayer( markerClusters );
+    }
+  });
+</script>

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -441,6 +441,25 @@ main {
 	margin-left: 0 !important;
 }
 
+#global-map {
+  height: 420px;
+}
+
+.marker {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background-color: $p2pu-blue;
+  cursor: default;
+
+  &.with-popup {
+    cursor: pointer;
+    background-color: $p2pu-orange;
+    width: 15px;
+    height: 15px;
+  }
+}
+
 @media (max-width: map-get($grid-breakpoints, "md")) {
 	body {
 		font-size: $font-size-base;

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -458,19 +458,19 @@ main {
   background-color: $gray-darker;
   cursor: default;
 
-  &.year2019 {
+  &.orange {
   	background-color: $p2pu-orange;
   }
 
-  &.year2018 {
+  &.yellow {
   	background-color: $p2pu-yellow;
   }
 
-  &.year2017 {
+  &.green {
   	background-color: $p2pu-green;
   }
 
-  &.year2016 {
+  &.blue {
   	background-color: $p2pu-blue;
   }
 
@@ -479,6 +479,30 @@ main {
     background-color: $p2pu-orange;
     width: 15px;
     height: 15px;
+  }
+}
+
+.marker-cluster {
+
+  &.marker-cluster-small {
+		background-color: transparentize($p2pu-green, 0.4);
+		> div {
+			background-color: transparentize($p2pu-green, 0.4);
+		}
+  }
+
+  &.marker-cluster-medium {
+		background-color: transparentize($p2pu-yellow, 0.4);
+		> div {
+			background-color: transparentize($p2pu-yellow, 0.4);
+		}
+  }
+
+  &.marker-cluster-large {
+		background-color: transparentize($p2pu-orange, 0.4);
+		> div {
+			background-color: transparentize($p2pu-orange, 0.4);
+		}
   }
 }
 

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -452,6 +452,10 @@ main {
   background-color: $p2pu-blue;
   cursor: default;
 
+  &.active {
+  	background-color: $p2pu-orange;
+  }
+
   &.with-popup {
     cursor: pointer;
     background-color: $p2pu-orange;

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -442,13 +442,17 @@ main {
 }
 
 #map-section {
+	padding-top: 0;
+
 	.container {
 		position: relative;
+		margin-bottom: $padding-sm;
 	}
 }
 
 #global-map {
-  height: 420px;
+  height: 500px;
+  max-height: calc(100vh - 52px);
 }
 
 .marker {
@@ -456,34 +460,14 @@ main {
   height: 15px;
   border-radius: 50%;
   background-color: $gray-darker;
-  cursor: default;
+  cursor: pointer;
 
-  &.orange {
-  	background-color: $p2pu-orange;
-  }
-
-  &.yellow {
-  	background-color: $p2pu-yellow;
-  }
-
-  &.green {
-  	background-color: $p2pu-green;
-  }
-
-  &.blue {
+  &.active {
   	background-color: $p2pu-blue;
-  }
-
-  &.with-popup {
-    cursor: pointer;
-    background-color: $p2pu-orange;
-    width: 15px;
-    height: 15px;
   }
 }
 
 .marker-cluster {
-
   &.marker-cluster-small {
 		background-color: transparentize($p2pu-green, 0.4);
 		> div {
@@ -511,7 +495,6 @@ main {
   bottom: 0;
   right: 0;
   background: rgba(255, 255, 255, 0.8);
-  margin-right: 20px;
   overflow: auto;
   border-radius: 3px;
 }
@@ -520,8 +503,9 @@ main {
   padding: 10px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   line-height: 18px;
-  margin-bottom: 40px;
-  width: 100px;
+  margin-bottom: 25px;
+  margin-right: 25px;
+  z-index: 99999;
 }
 
 .legend-key {
@@ -530,20 +514,9 @@ main {
   width: 10px;
   height: 10px;
   margin-right: 5px;
+  background-color: $gray-darker;
 
-  &.year2019 {
-  	background-color: $p2pu-orange;
-  }
-
-  &.year2018 {
-  	background-color: $p2pu-yellow;
-  }
-
-  &.year2017 {
-  	background-color: $p2pu-green;
-  }
-
-  &.year2016 {
+  &.active {
   	background-color: $p2pu-blue;
   }
 }

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -441,6 +441,12 @@ main {
 	margin-left: 0 !important;
 }
 
+#map-section {
+	.container {
+		position: relative;
+	}
+}
+
 #global-map {
   height: 420px;
 }
@@ -449,11 +455,23 @@ main {
   width: 15px;
   height: 15px;
   border-radius: 50%;
-  background-color: $p2pu-blue;
+  background-color: $gray-darker;
   cursor: default;
 
-  &.active {
+  &.year2019 {
   	background-color: $p2pu-orange;
+  }
+
+  &.year2018 {
+  	background-color: $p2pu-yellow;
+  }
+
+  &.year2017 {
+  	background-color: $p2pu-green;
+  }
+
+  &.year2016 {
+  	background-color: $p2pu-blue;
   }
 
   &.with-popup {
@@ -461,6 +479,48 @@ main {
     background-color: $p2pu-orange;
     width: 15px;
     height: 15px;
+  }
+}
+
+.map-overlay {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.8);
+  margin-right: 20px;
+  overflow: auto;
+  border-radius: 3px;
+}
+
+#legend {
+  padding: 10px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  line-height: 18px;
+  margin-bottom: 40px;
+  width: 100px;
+}
+
+.legend-key {
+  display: inline-block;
+  border-radius: 20%;
+  width: 10px;
+  height: 10px;
+  margin-right: 5px;
+
+  &.year2019 {
+  	background-color: $p2pu-orange;
+  }
+
+  &.year2018 {
+  	background-color: $p2pu-yellow;
+  }
+
+  &.year2017 {
+  	background-color: $p2pu-green;
+  }
+
+  &.year2016 {
+  	background-color: $p2pu-blue;
   }
 }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -70,7 +70,7 @@
 
   // Initialize mapbox map
 
-  var url = 'https://learningcircles.p2pu.org/api/learningcircles/?active=true'
+  var url = 'http://localhost:8000/api/learningcircles/'
 
   mapboxgl.accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
   var map = new mapboxgl.Map({
@@ -91,9 +91,13 @@
       success: (res) => {
         $.each(res.items, function(index, item) {
           if (item.latitude && item.longitude) {
+
             // create a HTML element for each feature
             var el = document.createElement('div');
-            el.className = 'marker';
+            var active = Date.parse(item.end_date) > Date.now()
+            console.log('active', active)
+            var classes = active ? "marker active" : "marker";
+            el.className = classes;
             el.setAttribute('title', item.course_title);
 
             // make a marker for each feature and add to the map

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -82,7 +82,7 @@
   });
 
   var nav = new mapboxgl.NavigationControl();
-  map.addControl(nav, 'bottom-right');
+  map.addControl(nav, 'top-right');
 
   $.ajax({
       url,
@@ -94,9 +94,8 @@
 
             // create a HTML element for each feature
             var el = document.createElement('div');
-            var active = Date.parse(item.end_date) > Date.now()
-            console.log('active', active)
-            var classes = active ? "marker active" : "marker";
+            var year = item.start_date.substr(0,4)
+            var classes = "marker year" + year
             el.className = classes;
             el.setAttribute('title', item.course_title);
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -68,4 +68,41 @@
     });
   })
 
+  // Initialize mapbox map
+
+  var url = 'https://learningcircles.p2pu.org/api/learningcircles/?active=true'
+
+  mapboxgl.accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
+  var map = new mapboxgl.Map({
+    container: 'global-map',
+    style: 'mapbox://styles/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw',
+    zoom: 1.6,
+    scrollZoom: false,
+    center: [-31.949833, 27.947533],
+  });
+
+  var nav = new mapboxgl.NavigationControl();
+  map.addControl(nav, 'bottom-right');
+
+  $.ajax({
+      url,
+      dataType: 'JSONP',
+      type: 'GET',
+      success: (res) => {
+        $.each(res.items, function(index, item) {
+          if (item.latitude && item.longitude) {
+            // create a HTML element for each feature
+            var el = document.createElement('div');
+            el.className = 'marker';
+            el.setAttribute('title', item.course_title);
+
+            // make a marker for each feature and add to the map
+            new mapboxgl.Marker(el)
+            .setLngLat([item.longitude, item.latitude])
+            .addTo(map);
+          }
+        })
+      }
+    });
+
 })(jQuery)

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -70,10 +70,10 @@
 
   // Initialize mapbox map
 
-  var url = 'http://localhost:8000/api/learningcircles/'
+  var url = 'http://localhost:8000/api/learning-circles-map/'
 
   var accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
-  var tileLayer = "https://api.mapbox.com/styles/v1/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjamtoM255YTQwMGw2M3dtcnNqd2FibTk5In0.mlkvZ9zSFY0kJBd9HEG2rg"
+  var tileLayer = "https://api.mapbox.com/styles/v1/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw/tiles/256/{z}/{x}/{y}@2x?access_token=" + accessToken;
 
   var mymap = L.map('global-map').setView([22, -26], 2.2);
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -73,10 +73,11 @@
   var url = 'http://localhost:8000/api/learningcircles/'
 
   var accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
+  var tileLayer = "https://api.mapbox.com/styles/v1/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjamtoM255YTQwMGw2M3dtcnNqd2FibTk5In0.mlkvZ9zSFY0kJBd9HEG2rg"
 
-  var mymap = L.map('global-map').setView([60, -0.09], 2);
+  var mymap = L.map('global-map').setView([22, -26], 2.2);
 
-  L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=' + accessToken, {
+  L.tileLayer(tileLayer, {
       attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
       maxZoom: 18,
       id: 'mapbox.streets',
@@ -84,6 +85,7 @@
   }).addTo(mymap);
 
   var markerClusters = L.markerClusterGroup();
+  var markerIcon = L.divIcon({className: 'marker blue'});
 
   $.ajax({
     url,
@@ -92,7 +94,7 @@
     success: (res) => {
       $.each(res.items, function(index, item) {
         if (item.latitude && item.longitude) {
-          var m = L.marker( [item.latitude, item.longitude] )
+          var m = L.marker( [item.latitude, item.longitude], { icon: markerIcon } )
           markerClusters.addLayer( m );
         }
       })

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -68,38 +68,4 @@
     });
   })
 
-  // Initialize mapbox map
-
-  var url = 'http://localhost:8000/api/learning-circles-map/'
-
-  var accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
-  var tileLayer = "https://api.mapbox.com/styles/v1/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw/tiles/256/{z}/{x}/{y}@2x?access_token=" + accessToken;
-
-  var mymap = L.map('global-map').setView([22, -26], 2.2);
-
-  L.tileLayer(tileLayer, {
-      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-      maxZoom: 18,
-      id: 'mapbox.streets',
-      accessToken: accessToken
-  }).addTo(mymap);
-
-  var markerClusters = L.markerClusterGroup();
-  var markerIcon = L.divIcon({className: 'marker blue'});
-
-  $.ajax({
-    url,
-    dataType: 'JSONP',
-    type: 'GET',
-    success: (res) => {
-      $.each(res.items, function(index, item) {
-        if (item.latitude && item.longitude) {
-          var m = L.marker( [item.latitude, item.longitude], { icon: markerIcon } )
-          markerClusters.addLayer( m );
-        }
-      })
-      mymap.addLayer( markerClusters );
-    }
-  });
-
 })(jQuery)

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -72,40 +72,32 @@
 
   var url = 'http://localhost:8000/api/learningcircles/'
 
-  mapboxgl.accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
-  var map = new mapboxgl.Map({
-    container: 'global-map',
-    style: 'mapbox://styles/sharon-nomadic-labs/cjokl5im306372rnzp5rsykzw',
-    zoom: 1.6,
-    scrollZoom: false,
-    center: [-31.949833, 27.947533],
-  });
+  var accessToken = 'pk.eyJ1Ijoic2hhcm9uLW5vbWFkaWMtbGFicyIsImEiOiJjanJtY2xuc2MwaG95NDNtbmUwa3o5bjRpIn0.fZpeaYNgU3Nh5NAcNLW5BQ';
 
-  var nav = new mapboxgl.NavigationControl();
-  map.addControl(nav, 'top-right');
+  var mymap = L.map('global-map').setView([60, -0.09], 2);
+
+  L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=' + accessToken, {
+      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+      maxZoom: 18,
+      id: 'mapbox.streets',
+      accessToken: accessToken
+  }).addTo(mymap);
+
+  var markerClusters = L.markerClusterGroup();
 
   $.ajax({
-      url,
-      dataType: 'JSONP',
-      type: 'GET',
-      success: (res) => {
-        $.each(res.items, function(index, item) {
-          if (item.latitude && item.longitude) {
-
-            // create a HTML element for each feature
-            var el = document.createElement('div');
-            var year = item.start_date.substr(0,4)
-            var classes = "marker year" + year
-            el.className = classes;
-            el.setAttribute('title', item.course_title);
-
-            // make a marker for each feature and add to the map
-            new mapboxgl.Marker(el)
-            .setLngLat([item.longitude, item.latitude])
-            .addTo(map);
-          }
-        })
-      }
-    });
+    url,
+    dataType: 'JSONP',
+    type: 'GET',
+    success: (res) => {
+      $.each(res.items, function(index, item) {
+        if (item.latitude && item.longitude) {
+          var m = L.marker( [item.latitude, item.longitude] )
+          markerClusters.addLayer( m );
+        }
+      })
+      mymap.addLayer( markerClusters );
+    }
+  });
 
 })(jQuery)

--- a/en/index.html
+++ b/en/index.html
@@ -27,6 +27,20 @@ bundles:
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.js'></script>
 
+	<!-- Leaflet -->
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
+   integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
+   crossorigin=""/>
+  <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
+   integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
+   crossorigin=""></script>
+
+  <script type="text/javascript" src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+
+
 	<!-- Custom CSS -->
 	<link rel="stylesheet" href="{{ "/assets/css/p2pu-index.css" | prepend: site.baseurl }}">
 	<link rel="shortcut icon" href="{{ "/assets/images/favicon.ico" | prepend: site.baseurl }}">

--- a/en/index.html
+++ b/en/index.html
@@ -23,19 +23,10 @@ bundles:
       rel="stylesheet">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
 
-	<!-- Mapbox -->
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.js'></script>
-
 	<!-- Leaflet -->
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
    integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
    crossorigin=""/>
-  <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
-   integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
-   crossorigin=""></script>
-
-  <script type="text/javascript" src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
 
   <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
   <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
@@ -90,21 +81,34 @@ bundles:
 	</section>
 
 	<section id="learning-circles">
-		<div class="header-text">
-			<h1 class="bold centered">Learning circles are free study groups for people who want to take online classes together and in-person.</h1>
-		</div>
+		<div class="container">
+			<div class="header-text">
+				<h1 class="bold centered">Learning circles are free study groups for people who want to take online classes together and in-person.</h1>
+			</div>
 
-		<div class="overview">
-			<div class="container">
-				<div id="stats"></div>
+			<div class="overview">
+				<div class="container">
+					<div id="stats"></div>
+				</div>
 			</div>
 		</div>
 	</section>
 
 	<section id="map-section">
-		<div class="container">
-			<div id="global-map"></div>
-		</div>
+	  <div class="container">
+	    <div id="global-map"></div>
+	    <div class='map-overlay' id='legend'>
+	      <div>
+	        <span class="legend-key active"></span>
+	        <span>Active</span>
+	      </div>
+
+	      <div>
+	        <span class="legend-key"></span>
+	        <span>Completed</span>
+	      </div>
+	    </div>
+	  </div>
 	</section>
 
 	<section id="upcoming-meetings" data-aos="fade-up">
@@ -273,6 +277,13 @@ bundles:
 
 <script src="{{ site.baseurl }}/assets/js/vendor/scroll-magic.min.js"></script>
 <script src="{{ site.baseurl }}/assets/js/index.js"></script>
+
+<script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
+  integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
+  crossorigin=""></script>
+<script type="text/javascript" src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+
+{% include map_js.html %}
 
 {% include ga.html %}
 

--- a/en/index.html
+++ b/en/index.html
@@ -22,6 +22,11 @@ bundles:
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+
+	<!-- Mapbox -->
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.js'></script>
+
 	<!-- Custom CSS -->
 	<link rel="stylesheet" href="{{ "/assets/css/p2pu-index.css" | prepend: site.baseurl }}">
 	<link rel="shortcut icon" href="{{ "/assets/images/favicon.ico" | prepend: site.baseurl }}">
@@ -79,6 +84,12 @@ bundles:
 			<div class="container">
 				<div id="stats"></div>
 			</div>
+		</div>
+	</section>
+
+	<section id="map-section">
+		<div class="container">
+			<div id="global-map"></div>
 		</div>
 	</section>
 

--- a/en/index.html
+++ b/en/index.html
@@ -90,6 +90,27 @@ bundles:
 	<section id="map-section">
 		<div class="container">
 			<div id="global-map"></div>
+			<div class='map-overlay' id='legend'>
+				<div>
+					<span class="legend-key year2019"></span>
+					<span>2019</span>
+				</div>
+
+				<div>
+					<span class="legend-key year2018"></span>
+					<span>2018</span>
+				</div>
+
+				<div>
+					<span class="legend-key year2017"></span>
+					<span>2017</span>
+				</div>
+
+				<div>
+					<span class="legend-key year2016"></span>
+					<span>2016</span>
+				</div>
+			</div>
 		</div>
 	</section>
 

--- a/en/index.html
+++ b/en/index.html
@@ -104,27 +104,6 @@ bundles:
 	<section id="map-section">
 		<div class="container">
 			<div id="global-map"></div>
-			<div class='map-overlay' id='legend'>
-				<div>
-					<span class="legend-key year2019"></span>
-					<span>2019</span>
-				</div>
-
-				<div>
-					<span class="legend-key year2018"></span>
-					<span>2018</span>
-				</div>
-
-				<div>
-					<span class="legend-key year2017"></span>
-					<span>2017</span>
-				</div>
-
-				<div>
-					<span class="legend-key year2016"></span>
-					<span>2016</span>
-				</div>
-			</div>
 		</div>
 	</section>
 


### PR DESCRIPTION
@dirkcuys I ended up putting the environment variables in the _config.yml file. Can you add a production config file on Travis, that would override the first one? As suggested here: https://keirwhitaker.com/blog/setting-development-variables-in-jekyll/

The production config would just need to override the settings for `mapbox_access_token` and `default_base_api_endpoint`. The default endpoint on production should be learningcircles.p2pu.org. The mapbox access token in the current config file is from my personal account, so I think it's fine to have that on github and use it for development, but I think we should create a P2PU account on mapbox and generate a new access token there for use on production. 

